### PR TITLE
RFC form for WIP-ESGF interactions 

### DIFF
--- a/.github/ISSUE_TEMPLATE/wip_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/wip_rfc.yml
@@ -5,10 +5,10 @@ labels:
   - WIP-RFC
 body:
   - type: input
+    id: summary
     attributes:
-      label: Summary
-      id: summary
-      description: >
+      label: Summary  
+      description: |
         *Brief* high-level summary of the integration/implementation
         request (one paragraph)..
       validations:
@@ -17,9 +17,8 @@ body:
     attributes:
       label: Infrastructure components
       id: infrastructure
-      description: >
+      description: |
         Identify the affected components of CMIP infrastructure. 
-
 
         This should be concise and specific (e.g., names github repositories of relevant software packages). 
 
@@ -29,13 +28,12 @@ body:
       validations:
         required: true
   - type: input
+    id: priority-timeline
     attributes:
       label: Prioritization and timeline
-      id: priority-timeline
-      description: >
+      description: |
         *Briefly* indicate the priority of the integration request, and the
         timeline on which it is requested.
-
 
         Suggested guidelines for prioritization:
 
@@ -45,15 +43,14 @@ body:
 
         * Low: would be nice to have
 
-
         Rationale for prioritization and timeline can be explained below under [Motivation](#motivation).
       validations:
         required: true
   - type: input
+    id: motivation
     attributes:
       label: Motivation
-      id: motivation
-      description: >
+      description: |
         Explain why this request is important. This doesn't need to be
         brief. It can address:
 
@@ -67,9 +64,9 @@ body:
       validations:
         required: true
   - type: input
+    id: tech-details
     attributes:
       label: Technical details
-      id: tech-details
       description: >
         This section is for more detailed description of technical aspects
         of the integration request, such as:
@@ -84,9 +81,9 @@ body:
       validations:
         required: true
   - type: input
+    id: risks
     attributes:
       label: Risks
-      id: risks
       description: >
         Explain any known risks / drawbacks of carrying out the proposal.
 

--- a/.github/ISSUE_TEMPLATE/wip_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/wip_rfc.yml
@@ -37,11 +37,11 @@ body:
         Suggested guidelines for prioritization:
 
         * High: extremely important, perhaps critical
-
+        
         * Medium: important and beneficial, but can live without it
-
+        
         * Low: would be nice to have
-
+        
         Rationale for prioritization and timeline can be explained below under *Motivation*.
     validations:
       required: true
@@ -54,11 +54,11 @@ body:
         brief. It can address:
 
         * What use cases does it support? Who are the affected users?
-
+        
         * How does it support the ecosystem of WCRP/ESMO projects?
-
-        * How does it support provision of FAIR data? 
-
+        
+        * How does it support provision of FAIR data?
+        
         * What are the consequences of not doing this?
     validations:
       required: true
@@ -71,11 +71,11 @@ body:
         of the integration request, such as:
 
         * Pathway to implementation (road map)
-
+        
         * Dependencies on other infrastructure components
-
+        
         * Detailed information that will be passed between infrastructure components
-
+        
         * Potential obstacles to implementation
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/wip_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/wip_rfc.yml
@@ -13,9 +13,9 @@ body:
     validations:
       required: true
   - type: input
+    id: infrastructure
     attributes:
       label: Infrastructure components
-      id: infrastructure
       description: |
         Identify the affected components of CMIP infrastructure. 
 

--- a/.github/ISSUE_TEMPLATE/wip_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/wip_rfc.yml
@@ -23,7 +23,7 @@ body:
 
         If affected components are not initially known, these details should be added during the review/discussion phase. 
 
-        Notes on implementation and further technical details are given below under [Technical details](#technical-details).
+        Notes on implementation and further technical details are given below under *Technical details*.
     validations:
       required: true
   - type: input
@@ -42,7 +42,7 @@ body:
 
         * Low: would be nice to have
 
-        Rationale for prioritization and timeline can be explained below under [Motivation](#motivation).
+        Rationale for prioritization and timeline can be explained below under *Motivation*.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/wip_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/wip_rfc.yml
@@ -12,7 +12,7 @@ body:
         request (one paragraph)..
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: infrastructure
     attributes:
       label: Infrastructure components
@@ -26,7 +26,7 @@ body:
         Notes on implementation and further technical details are given below under *Technical details*.
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: priority-timeline
     attributes:
       label: Prioritization and timeline
@@ -45,7 +45,7 @@ body:
         Rationale for prioritization and timeline can be explained below under *Motivation*.
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: motivation
     attributes:
       label: Motivation
@@ -62,7 +62,7 @@ body:
         * What are the consequences of not doing this?
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: tech-details
     attributes:
       label: Technical details
@@ -79,7 +79,7 @@ body:
         * Potential obstacles to implementation
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: risks
     attributes:
       label: Risks

--- a/.github/ISSUE_TEMPLATE/wip_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/wip_rfc.yml
@@ -1,0 +1,95 @@
+name: WCRP-ESMO Infrastructure Panel - ESGF RFC
+description: Request for comment from ESGF on WIP proposal
+title: Request for comment from ESGF on WIP proposal
+labels:
+  - WIP-RFC
+body:
+  - type: input
+    attributes:
+      label: Summary
+      id: summary
+      description: >
+        *Brief* high-level summary of the integration/implementation
+        request (one paragraph)..
+      validations:
+        required: true
+  - type: input
+    attributes:
+      label: Infrastructure components
+      id: infrastructure
+      description: >
+        Identify the affected components of CMIP infrastructure. 
+
+
+        This should be concise and specific (e.g., names github repositories of relevant software packages). 
+
+        If affected components are not initially known, these details should be added during the review/discussion phase. 
+
+        Notes on implementation and further technical details are given below under [Technical details](#technical-details).
+      validations:
+        required: true
+  - type: input
+    attributes:
+      label: Prioritization and timeline
+      id: priority-timeline
+      description: >
+        *Briefly* indicate the priority of the integration request, and the
+        timeline on which it is requested.
+
+
+        Suggested guidelines for prioritization:
+
+        * High: extremely important, perhaps critical
+
+        * Medium: important and beneficial, but can live without it
+
+        * Low: would be nice to have
+
+
+        Rationale for prioritization and timeline can be explained below under [Motivation](#motivation).
+      validations:
+        required: true
+  - type: input
+    attributes:
+      label: Motivation
+      id: motivation
+      description: >
+        Explain why this request is important. This doesn't need to be
+        brief. It can address:
+
+        * What use cases does it support? Who are the affected users?
+
+        * How does it support the ecosystem of WCRP/ESMO projects?
+
+        * How does it support provision of FAIR data? 
+
+        * What are the consequences of not doing this?
+      validations:
+        required: true
+  - type: input
+    attributes:
+      label: Technical details
+      id: tech-details
+      description: >
+        This section is for more detailed description of technical aspects
+        of the integration request, such as:
+
+        * Pathway to implementation (road map)
+
+        * Dependencies on other infrastructure components
+
+        * Detailed information that will be passed between infrastructure components
+
+        * Potential obstacles to implementation
+      validations:
+        required: true
+  - type: input
+    attributes:
+      label: Risks
+      id: risks
+      description: >
+        Explain any known risks / drawbacks of carrying out the proposal.
+
+        How would the proposal negatively or positively impact resilience (is it critically dependent on one person or institute?)
+      validations:
+        required: true

--- a/.github/ISSUE_TEMPLATE/wip_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/wip_rfc.yml
@@ -1,8 +1,7 @@
 name: WCRP-ESMO Infrastructure Panel - ESGF RFC
 description: Request for comment from ESGF on WIP proposal
-title: Request for comment from ESGF on WIP proposal
-labels:
-  - WIP-RFC
+title: "Request for comment from ESGF on WIP proposal"
+labels: ["WIP-RFC"]
 body:
   - type: input
     id: summary

--- a/.github/ISSUE_TEMPLATE/wip_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/wip_rfc.yml
@@ -11,8 +11,8 @@ body:
       description: |
         *Brief* high-level summary of the integration/implementation
         request (one paragraph)..
-      validations:
-        required: true
+    validations:
+      required: true
   - type: input
     attributes:
       label: Infrastructure components
@@ -25,8 +25,8 @@ body:
         If affected components are not initially known, these details should be added during the review/discussion phase. 
 
         Notes on implementation and further technical details are given below under [Technical details](#technical-details).
-      validations:
-        required: true
+    validations:
+      required: true
   - type: input
     id: priority-timeline
     attributes:
@@ -44,8 +44,8 @@ body:
         * Low: would be nice to have
 
         Rationale for prioritization and timeline can be explained below under [Motivation](#motivation).
-      validations:
-        required: true
+    validations:
+      required: true
   - type: input
     id: motivation
     attributes:
@@ -61,8 +61,8 @@ body:
         * How does it support provision of FAIR data? 
 
         * What are the consequences of not doing this?
-      validations:
-        required: true
+    validations:
+      required: true
   - type: input
     id: tech-details
     attributes:
@@ -78,8 +78,8 @@ body:
         * Detailed information that will be passed between infrastructure components
 
         * Potential obstacles to implementation
-      validations:
-        required: true
+    validations:
+      required: true
   - type: input
     id: risks
     attributes:
@@ -88,5 +88,5 @@ body:
         Explain any known risks / drawbacks of carrying out the proposal.
 
         How would the proposal negatively or positively impact resilience (is it critically dependent on one person or institute?)
-      validations:
-        required: true
+    validations:
+      required: true


### PR DESCRIPTION
This PR adds an issue creation form that will allow the WIP to officially notify the ESGF-XC and development community about changes that we are proposing to the infrastructure in support of projects such as CMIP and CORDEX, and to solicit feedback on those proposals.

@JamesAnstey, @cmip-ipo this should cover WIP action 860


